### PR TITLE
Require prawn and prawn-table

### DIFF
--- a/lib/receipts/receipt.rb
+++ b/lib/receipts/receipt.rb
@@ -1,3 +1,6 @@
+require 'prawn'
+require 'prawn-table'
+
 module Receipts
   class Receipt < Prawn::Document
     attr_reader :attributes, :id, :company, :custom_font, :line_items, :logo, :message, :product


### PR DESCRIPTION
As mentioned in #1 prawn and prawn-table were left out of `lib/receipts/receipt.rb`.