### PR TITLE
[Fix] Avoid crashing when logo path is empty string

### DIFF
--- a/lib/receipts/receipt.rb
+++ b/lib/receipts/receipt.rb
@@ -48,10 +48,12 @@ module Receipts
       def header
         move_down 60
 
-        if company.has_key? :logo
-          image open(company.fetch(:logo)), height: 32
-        else
+        logo_path = company.fetch(:logo, '')
+
+        if logo_path.empty?
           move_down 32
+        else
+          image open(logo_path), height: 32
         end
 
         move_down 8


### PR DESCRIPTION
### Description
Currently, If `logo` key in the `company` hash is set to empty string then we are trying to open a file at `""`, which is causing the system to crash with an error.

### Proposed fix:
Do not try to open a file if the logo (path) provided is an empty string.

This Fix updates the logic around reading the logo path from company hash to avoid trying to open a file if the path provided is an empty string

### Use case:
let's say this gem is consumed in an application which deals with multiple company objects and some company object might not have a logo and some might. In this case, if we the `company` hash is built by setting the logo to an empty string (for a company that might not have logo or if it is deleted for some reason), then it should just ignore it rather than trying to open the non-existing file.