### PR TITLE
Use full width tables on Receipt & Invoice PDF

### DIFF
--- a/lib/receipts/invoice.rb
+++ b/lib/receipts/invoice.rb
@@ -100,7 +100,7 @@ module Receipts
 
         borders = line_items.length - 2
 
-        table(line_items, cell_style: { border_color: 'cccccc', inline_format: true }) do
+        table(line_items, width: bounds.width, cell_style: { border_color: 'cccccc', inline_format: true }) do
           cells.padding = 12
           cells.borders = []
           row(0..borders).borders = [:bottom]

--- a/lib/receipts/receipt.rb
+++ b/lib/receipts/receipt.rb
@@ -68,7 +68,7 @@ module Receipts
 
         borders = line_items.length - 2
 
-        table(line_items, cell_style: { border_color: 'cccccc', inline_format: true }) do
+        table(line_items, width: bounds.width, cell_style: { border_color: 'cccccc', inline_format: true }) do
           cells.padding = 12
           cells.borders = []
           row(0..borders).borders = [:bottom]


### PR DESCRIPTION
Right now the table width is dependent upon the content included.

I think this would be the expected layout, letting the table cells itself use all the available space.