### PR TITLE
Allow skipping generation during initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ r = Receipts::Receipt.new(
 )
 
 # Returns a string of the raw PDF
-r.render 
+r.render
 
 # Writes the PDF to disk
 r.render_file "examples/receipt.pdf"
@@ -105,6 +105,7 @@ You can pass the following options to generate a PDF:
     normal: Rails.root.join('app/assets/fonts/tradegothic/TradeGothic.ttf'),
   }
   ```
+* `skip_generate` - Boolean indicating if generation should be skipped during initialization. Useful if you need to manipulate the Prawn object directly before generating the document. Don't forget to run `#generate` manually - _Optional, defaults to `false`_
 
 Here's an example of where each option is displayed.
 
@@ -112,7 +113,7 @@ Here's an example of where each option is displayed.
 
 ### Formatting
 
-`details` and `line_items` allow inline formatting with Prawn. This allows you to use HTML tags to format text: `<b>` `<i>` `<u>` `<strikethrough>` `<sub>` `<sup>` `<font>` `<color>` `<link>` 
+`details` and `line_items` allow inline formatting with Prawn. This allows you to use HTML tags to format text: `<b>` `<i>` `<u>` `<strikethrough>` `<sub>` `<sup>` `<font>` `<color>` `<link>`
 
 See [the Prawn docs](https://prawnpdf.org/api-docs/2.3.0/Prawn/Text.html#text-instance_method) for more information.
 
@@ -192,7 +193,7 @@ class ChargesController < ApplicationController
     def set_charge
       @charge = current_user.charges.find(params[:id])
     end
-        
+
     def send_pdf
       # Render the PDF in memory and send as the response
       send_data @charge.receipt.render,

--- a/lib/receipts/base.rb
+++ b/lib/receipts/base.rb
@@ -11,12 +11,14 @@ module Receipts
       setup_fonts attributes[:font]
 
       @title = attributes.fetch(:title, self.class.title)
+      @attributes = attributes
+      skip_generate = attributes.delete(:skip_generate) || false
 
-      generate_from(attributes)
+      generate unless skip_generate
     end
 
-    def generate_from(attributes)
-      return if attributes.empty?
+    def generate(attributes = @attributes)
+      return if attributes.empty? || @generated.present?
 
       company = attributes.fetch(:company)
       header company: company
@@ -24,6 +26,7 @@ module Receipts
       render_billing_details company: company, recipient: attributes.fetch(:recipient)
       render_line_items attributes.fetch(:line_items)
       render_footer attributes.fetch(:footer, default_message(company: company))
+      @generated = true
     end
 
     def setup_fonts(custom_font = nil)


### PR DESCRIPTION
Useful if you need to manipulate the Prawn object directly before generating the document.