### PR TITLE
docs: update README for `render_line_items` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ You can also use the Receipts helpers in your custom PDFs at the current cursor 
 
 ```ruby
 receipt.text("Custom header")
-receipt.render_line_items([
+receipt.render_line_items(line_items: [
   ["my line items"]
 ])
 receipt.render_footer("This is a custom footer using the Receipts helper")


### PR DESCRIPTION
Super small PR here. Noticed a small discrepancy in the README for Custom Rendering with the `render_line_items` function.